### PR TITLE
Update actions

### DIFF
--- a/.github/actions/apt_requirements/action.yml
+++ b/.github/actions/apt_requirements/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Export apt requirements
       id: export-apt-requirements
       run: |
-        echo ::set-output name=apt-packages::$( cat ${{ inputs.requirements_file }} )
+        echo "apt-packages=$( cat ${{ inputs.requirements_file }} )" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache apt packages

--- a/.github/workflows/detect_changes.yml
+++ b/.github/workflows/detect_changes.yml
@@ -45,7 +45,8 @@ jobs:
       run: |
         git branch -a --list | cat
         BACKEND_CHANGES=$(git diff --compact-summary origin/${{ github.base_ref }} -- ${{ inputs.backend_directories }} | head -n -1 | wc -l)
-        echo "::set-output name=backend::$BACKEND_CHANGES"
+        echo "backend=$BACKEND_CHANGES" >> $GITHUB_OUTPUT
+
 
     - name: Generate diffs for frontend
       if: ${{inputs.frontend_directories != ''}}
@@ -53,4 +54,5 @@ jobs:
       run: |
         git branch -a --list | cat
         FRONTEND_CHANGES=$(git diff --compact-summary origin/${{ github.base_ref }} -- ${{ inputs.frontend_directories }} | head -n -1 | wc -l)
-        echo "::set-output name=frontend::$FRONTEND_CHANGES"
+        echo "frontend=$FRONTEND_CHANGES" >> $GITHUB_OUTPUT
+

--- a/.github/workflows/release_and_tag.yml
+++ b/.github/workflows/release_and_tag.yml
@@ -32,7 +32,7 @@ jobs:
         id: check-tag
         run: |
           if [[ ${{ github.event.pull_request.title }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+            echo "match=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Tag and Release

--- a/test/python_test/requirements.txt
+++ b/test/python_test/requirements.txt
@@ -1,3 +1,3 @@
-Django==4.1.1
-uWSGI==2.0.19
+Django==4.1.2
+uWSGI==2.0.20
 celery==5.2.7

--- a/workflow-templates/starter.yml
+++ b/workflow-templates/starter.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   detect-changes:
-    uses: certego/.github/.github/workflows/detect_changes.yml@main
+    uses: certego/.github/.github/workflows/detect_changes.yml@develop
     with:
       backend_directories: backend
       frontend_directories: frontend
@@ -23,7 +23,7 @@ jobs:
   python:
     if: ${{ needs.detect-changes.outputs.backend > 0 }}
     needs: detect-changes
-    uses: certego/.github/.github/workflows/python.yml@main
+    uses: certego/.github/.github/workflows/python.yml@develop
     with:
       working_directory: backend
 
@@ -73,7 +73,7 @@ jobs:
   node:
     if: ${{ needs.detect-changes.outputs.frontend > 0 }}
     needs: detect-changes
-    uses: certego/.github/.github/workflows/node.yml@main
+    uses: certego/.github/.github/workflows/node.yml@develop
     with:
       working_directory: frontend
 
@@ -86,10 +86,10 @@ jobs:
       use_coverage: true
       upload_coverage: true
       node_versions: >-
-        [ "16", "15", "14", "13" ]
+        [ "16", "17", "18" ]
 
   release_and_tag:
-    uses: certego/.github/.github/workflows/release_and_tag.yml@main
+    uses: certego/.github/.github/workflows/release_and_tag.yml@develop
     secrets: inherit
     with:
       publish_on_pypi: false # Token should be set on secret PYPI_API_TOKEN


### PR DESCRIPTION
[Fix #112](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)