### PR TITLE
CI: always refresh APT index before installing packages

### DIFF
--- a/.github/workflows/_python.yml
+++ b/.github/workflows/_python.yml
@@ -287,10 +287,11 @@ jobs:
           apt_requirements_file_path: ${{ inputs.packages_path }}
           git_reference: ${{ github.base_ref }}
       
+      # Always refresh the APT index. Skipping this on an APT cache hit left a
+      # stale index, so `apt-get install` returned 404 when a pinned package
+      # version was rotated out of the mirror. The update is cheap; the cache
+      # still serves the .deb downloads.
       - name: Refresh APT repositories
-        if: >
-          steps.restore_apt_cache_pr.outputs.cache-hit != 'true' &&
-          steps.restore_apt_cache_target_branch.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
         shell: bash

--- a/workflows/_python.yml
+++ b/workflows/_python.yml
@@ -287,10 +287,11 @@ jobs:
           apt_requirements_file_path: ${{ inputs.packages_path }}
           git_reference: ${{ github.base_ref }}
       
+      # Always refresh the APT index. Skipping this on an APT cache hit left a
+      # stale index, so `apt-get install` returned 404 when a pinned package
+      # version was rotated out of the mirror. The update is cheap; the cache
+      # still serves the .deb downloads.
       - name: Refresh APT repositories
-        if: >
-          steps.restore_apt_cache_pr.outputs.cache-hit != 'true' &&
-          steps.restore_apt_cache_target_branch.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
         shell: bash


### PR DESCRIPTION
The "Refresh APT repositories" step ran `apt-get update` only on an APT cache miss. On a cache hit the index was left stale, so `apt-get install` failed with 404 Not Found when a pinned package version had been rotated out of the mirror (e.g. libcurl4-openssl-dev). Run `apt-get update` unconditionally: it is cheap and the APT cache still serves the .deb downloads.

Applied to workflows/_python.yml and its hard-linked .github/ self-test copy.