### PR TITLE
Fix always-truthy if expression in _detect_changes.yml

### DIFF
--- a/.github/workflows/_detect_changes.yml
+++ b/.github/workflows/_detect_changes.yml
@@ -72,7 +72,7 @@ jobs:
         clean: false
 
     - name: Generate summary
-      if: ${{inputs.backend_directories != ''}} | ${{inputs.frontend_directories != ''}} | ${{inputs.infrastructure_directories != ''}}
+      if: ${{ inputs.backend_directories != '' || inputs.frontend_directories != '' || inputs.infrastructure_directories != '' }}
       run: |
         echo "### Detect Changes summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/workflows/_detect_changes.yml
+++ b/workflows/_detect_changes.yml
@@ -72,7 +72,7 @@ jobs:
         clean: false
 
     - name: Generate summary
-      if: ${{inputs.backend_directories != ''}} | ${{inputs.frontend_directories != ''}} | ${{inputs.infrastructure_directories != ''}}
+      if: ${{ inputs.backend_directories != '' || inputs.frontend_directories != '' || inputs.infrastructure_directories != '' }}
       run: |
         echo "### Detect Changes summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- The `Generate summary` step in `_detect_changes.yml` combined three separate `${{ }}` expressions with literal `|` characters outside the replacement tokens, which GitHub Actions treats as literal text — making the condition always evaluate to truthy regardless of input values (surfaced as a workflow syntax warning when consumed downstream, e.g. certego/certego-tools#328).
- Combined the three checks into a single `${{ }}` expression using the `||` operator.
- Applied the same fix to both copies of the file (`workflows/_detect_changes.yml` and `.github/workflows/_detect_changes.yml`).

## Test plan
- [ ] CI run on this PR should show no more "Conditional expression contains literal text outside replacement tokens" warning
- [ ] Verify the `Generate summary` step still runs when any of `backend_directories`/`frontend_directories`/`infrastructure_directories` is non-empty, and is skipped when all are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)